### PR TITLE
fix(ci): avoid brew deprecation on ubuntu gh action image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,14 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
         go-version: ^1.19
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3  
+      uses: actions/checkout@v3
     - name: Build Enrich
       working-directory: enrich
       run: go build -mod=vendor ./...
@@ -25,7 +25,7 @@ jobs:
       run: go build -mod=vendor ./...
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
   vet:
     name: Vet
-    runs-on: ubuntu-latest 
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Vet for enrich
@@ -70,7 +70,7 @@ jobs:
   test:
     name: Test
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -92,7 +92,7 @@ jobs:
   run:
     name: Run
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install CLI
@@ -109,5 +109,3 @@ jobs:
         run: |
           go mod vendor
           meroxa apps run
-          
-    


### PR DESCRIPTION
Currently, CI is broken due to a recent change in the tooling provided with the github action's `ubuntu-latest` image: https://github.com/actions/runner-images/issues/6283

With this change, we're using `macos-latest` instead of the Ubuntu image by default when building and using the CLI for running automated integration tests.

### Before

https://github.com/meroxa/turbine-go-examples/actions/runs/3388014094/jobs/5630769352

### After

