### PR TITLE
Always vendor simple app before doing a test run on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Run simple with CLI
         working-directory: simple
         run: |
+          go mod vendor
           meroxa apps run
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
With this change, we'll automatically vendor the simple app example, before running the app locally during our Github CI workflow.

Follow-up to https://github.com/meroxa/turbine-go-examples/pull/24 to hopefully resolve the current CI issue: https://github.com/meroxa/turbine-go-examples/actions/runs/3388984513/jobs/5631589100